### PR TITLE
Added building click modal and fly to

### DIFF
--- a/components/Map/index.tsx
+++ b/components/Map/index.tsx
@@ -1,7 +1,7 @@
 import type { FunctionComponent } from 'react'
 import type {
-  IMapboxCallbackParams,
-  MapboxCallback,
+  IOnBuildingClickedParams,
+  OnBuildingClicked,
   IMapLayerParams
 } from '~/types/components/Map'
 import { useState } from 'react'
@@ -21,15 +21,15 @@ export const MapPopup: FunctionComponent = () =>
 
 interface IMapProps {
   className?: string
-  callbackRegistration: (callback: MapboxCallback) => void
-  callback: MapboxCallback
+  onBuildingClickedRegistration: (onBuildingClicked: OnBuildingClicked) => void
+  onBuildingClicked: OnBuildingClicked
   selectedTourNode: ITourNode | null
 }
 
 const Map: FunctionComponent<IMapProps> = ({
   className = '',
-  callbackRegistration,
-  callback,
+  onBuildingClickedRegistration,
+  onBuildingClicked,
   selectedTourNode
 }) => {
   const [hash, setHash] = useState<number>(0)
@@ -49,7 +49,7 @@ const Map: FunctionComponent<IMapProps> = ({
     bearing: 45
   })
 
-  callbackRegistration(({ location, buildingIds }: IMapboxCallbackParams) => {
+  onBuildingClickedRegistration(({ location, buildingIds }: IOnBuildingClickedParams) => {
     const buildingObj: { [key: string]: true } = {}
     buildingIds && buildingIds.forEach((id: string | number) => {
       buildingObj[`${id}`] = true
@@ -62,7 +62,7 @@ const Map: FunctionComponent<IMapProps> = ({
       longitude: location.lng,
       latitude: location.lat,
       zoom: 17,
-      transitionDuration: 1000,
+      transitionDuration: 450,
       transitionInterpolator: new FlyToInterpolator()
     })
   })
@@ -76,7 +76,7 @@ const Map: FunctionComponent<IMapProps> = ({
     zoom: viewState.zoom,
     hash,
     buildingIds: buildingIds,
-    callback
+    onBuildingClicked
   }
 
   return <div className={`${cn.map} ${className}`}>
@@ -98,7 +98,7 @@ const Map: FunctionComponent<IMapProps> = ({
       />
     </DeckGLReact.DeckGL>
     <div style={{ position: "absolute", left: 0, bottom: 0, zIndex: 1 }}>
-      <button onClick={() => callback({
+      <button onClick={() => onBuildingClicked({
         location: new LngLat(153.0437, -27.497925),
         buildingProperty: null
       })}>

--- a/components/Map/index.tsx
+++ b/components/Map/index.tsx
@@ -21,14 +21,14 @@ export const MapPopup: FunctionComponent = () =>
 
 interface IMapProps {
   className?: string
-  onBuildingClickedRegistration: (onBuildingClicked: OnBuildingClicked) => void
+  flyToRegistration: (onBuildingClicked: OnBuildingClicked) => void
   onBuildingClicked: OnBuildingClicked
   selectedTourNode: ITourNode | null
 }
 
 const Map: FunctionComponent<IMapProps> = ({
   className = '',
-  onBuildingClickedRegistration,
+  flyToRegistration,
   onBuildingClicked,
   selectedTourNode
 }) => {
@@ -49,11 +49,7 @@ const Map: FunctionComponent<IMapProps> = ({
     bearing: 45
   })
 
-  onBuildingClickedRegistration(({ location, buildingIds }: IOnBuildingClickedParams) => {
-    const buildingObj: { [key: string]: true } = {}
-    buildingIds && buildingIds.forEach((id: string | number) => {
-      buildingObj[`${id}`] = true
-    })
+  flyToRegistration(({ location }: IOnBuildingClickedParams) => {
     // update hash
     setHash(hash + 1);
     //setBuildingIds(buildingObj);

--- a/components/Map/layers.ts
+++ b/components/Map/layers.ts
@@ -122,10 +122,10 @@ export function GetLayers(params: IMapLayerParams) {
           onHover: () => {},
           // click actions are used to activate any supplemental features of a building, such as rendering text
           onClick: (f: any) => {
-            const id = `${f.object.properties["@id"]}`
-            if (params.buildingIds[id]) {
-              params.callback({
-                location: new MapBox.LngLat(f.lngLat[0], f.lngLat[1]), buildingProperty: f.object.properties
+            if (f.object.properties) {
+              params.onBuildingClicked({
+                location: new MapBox.LngLat(f.lngLat[0], f.lngLat[1]), 
+                buildingProperty: f.object.properties
               })
             }
           }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,7 +50,6 @@ const tour: ITourNode[] = [
 
 const Index: FunctionComponent = () => {
   const [selectedTourNode, setSelectedTourNode] = useState<ITourNode | null>(tour[0])
-  const [infoText, setInfoText] = useState<string | null>(null)
   const callbacks: Array<MapboxCallback> = []
   const addCallback = (callback: MapboxCallback) => callbacks.push(callback)
 
@@ -61,10 +60,8 @@ const Index: FunctionComponent = () => {
   }: IMapboxCallbackParams): void => {
     if (!!buildingProperty) {
       console.log("building clicked", buildingProperty)
-      setInfoText(buildingProperty.info ? buildingProperty.info : null)
       return
     }
-    setInfoText(null)
     callbacks.forEach(callback => callback({ location, buildingIds }))
   }
 
@@ -73,16 +70,6 @@ const Index: FunctionComponent = () => {
     setSelectedTourNode(node)
     flyTo({ location, buildingIds, buildingProperty: null })
   }
-
-  const InfoText: FunctionComponent = () =>
-    <div style={{
-      position: 'absolute',
-      right: '100px',
-      bottom: '100px',
-      backgroundColor: 'white'
-    }}>
-      { infoText || '' }
-    </div>
 
   return (
   <BaseLayout>
@@ -97,10 +84,10 @@ const Index: FunctionComponent = () => {
           selectedTourNode={selectedTourNode}
         />
       </div>
+      
       { selectedTourNode &&
         <TourModal selectedTourNode={ selectedTourNode } />
       }
-      <InfoText />
 
       <TourBar tour={ tour } handleTourClick={ handleTourClick } selectedTourNode={ selectedTourNode } />
     </main>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,8 +50,12 @@ const tour: ITourNode[] = [
 
 const Index: FunctionComponent = () => {
   const [selectedTourNode, setSelectedTourNode] = useState<ITourNode | null>(tour[0])
-  const onBuildingClickedListeners: Array<OnBuildingClicked> = []
-  const addOnBuildingClicked = (onBuildingClicked: OnBuildingClicked) => onBuildingClickedListeners.push(onBuildingClicked)
+  let flyToListeners: Array<OnBuildingClicked> = []
+  const addFlyToListener = (onBuildingClicked: OnBuildingClicked) => {
+    // TODO(odbol): figure out a better way to set state on the map
+    flyToListeners = [];
+    flyToListeners.push(onBuildingClicked);
+  };
 
   const selectTour = (tour: ITourNode) => {
     const { location, buildingIds } = tour;
@@ -80,7 +84,7 @@ const Index: FunctionComponent = () => {
     location,
     buildingIds = []
   }: IOnBuildingClickedParams): void => {
-    onBuildingClickedListeners.forEach(onBuildingClicked => onBuildingClicked({ location, buildingIds }));
+    flyToListeners.forEach(onBuildingClicked => onBuildingClicked({ location, buildingIds }));
   }
 
   return (
@@ -91,7 +95,7 @@ const Index: FunctionComponent = () => {
     <main className={cn.index}>
       <div style={{ position: "absolute", left: 0, top: 0, right: 0, bottom: 0, overflow: "hidden" }}>
         <DynamicMap
-          onBuildingClickedRegistration={addOnBuildingClicked}
+          flyToRegistration={addFlyToListener}
           onBuildingClicked={onBuildingClicked}
           selectedTourNode={selectedTourNode}
         />

--- a/types/components/Map.d.ts
+++ b/types/components/Map.d.ts
@@ -3,13 +3,13 @@ export interface ILngLat {
   lat: number
 }
 
-export interface IMapboxCallbackParams {
+export interface IOnBuildingClickedParams {
   location: LngLat
   buildingIds?: Array<(string | number)>
   buildingProperty?: any | null
 }
 
-export type MapboxCallback = ({ location, buildingProperty, buildingIds }: IMapboxCallbackParams) => void
+export type OnBuildingClicked = ({ location, buildingProperty, buildingIds }: IOnBuildingClickedParams) => void
 
 export interface IMapLayerParams {
   cam_lat: number
@@ -17,5 +17,5 @@ export interface IMapLayerParams {
   zoom: number
   hash: number
   buildingIds: { [key: string]: true },
-  callback: MapboxCallback
+  onBuildingClicked: OnBuildingClicked
 }


### PR DESCRIPTION
Clicking on a building will select the tour for that building (which will in turn show the modal for that building). It will also fly to the relevant buildings when you click a Tour dot in the nav.

Contains some hacky code which is a workaround for the earlier callbacks listening code... need to figure out a better way to trigger the flyTo with a state change or a prop or something.

Fixes #17 