### PR TITLE
Feature/script consume spreadsheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "next -p 3001",
     "dev-remote": "env API_HOST=https://world-of-jackson-git-dev.blacksocialists.now.sh next",
     "build": "next build",
+    "import-xlsx": "ts-node --script-mode scripts/import-property-list/ts-node-import-xlsx",
     "start": "next start",
     "storybook": "start-storybook"
   },
@@ -34,7 +35,8 @@
     "react-map-gl": "^5.2.5",
     "react-useportal": "^1.0.13",
     "styled-components": "^5.1.0",
-    "stylus": "^0.54.7"
+    "stylus": "^0.54.7",
+    "xlsx": "^0.16.9"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",
@@ -54,6 +56,7 @@
     "prettier": "^2.0.5",
     "stylus": "^0.54.7",
     "stylus-loader": "^3.0.2",
+    "ts-node": "^9.1.1",
     "typescript": "^3.8.3"
   }
 }

--- a/scripts/import-property-list/README.md
+++ b/scripts/import-property-list/README.md
@@ -1,0 +1,22 @@
+# Import Buildings from XLSX File
+## Usage
+- Configure an upload spreadsheet with columns named:
+-- Building Named
+-- Address
+-- Latitude
+- Fill the values for each building
+- Obtain your [personal access token](https://app.contentful.com/account/profile/cma_tokens) from Contentful
+- Add a file to the root of the `world-of-jackson` repo called ".env"
+- Add values to .env as such:
+```shell
+CONTENTFUL_SPACE_ID=<the World of Jackson Space ID (ex: 7zzvnrgo4q2e as of the creation of this doc)>
+CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN=<the above-mentioned personal access token>
+CONTENTFUL_ENVIRONMENT=<the desired environment (ex: dev or master)>
+```
+- In Terminal: 
+```shell
+> cd <world-of-jackson repo location>
+> yarn import-xlsx <path to import file (ex: ~/Desktop/importBuildings.xlsx)>
+```
+Any errors that occur during the import will be logged to your terminal.
+Access [Contentful](https://app.contentful.com/) to view/publish the posted buildings.

--- a/scripts/import-property-list/README.md
+++ b/scripts/import-property-list/README.md
@@ -1,7 +1,7 @@
 # Import Buildings from XLSX File
 ## Usage
 - Configure an upload spreadsheet with columns named:
--- Building Named
+-- Building Name
 -- Address
 -- Latitude
 - Fill the values for each building
@@ -13,7 +13,7 @@ CONTENTFUL_SPACE_ID=<the World of Jackson Space ID (ex: 7zzvnrgo4q2e as of the c
 CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN=<the above-mentioned personal access token>
 CONTENTFUL_ENVIRONMENT=<the desired environment (ex: dev or master)>
 ```
-- In Terminal: 
+- In Terminal:
 ```shell
 > cd <world-of-jackson repo location>
 > yarn import-xlsx <path to import file (ex: ~/Desktop/importBuildings.xlsx)>

--- a/scripts/import-property-list/README.md
+++ b/scripts/import-property-list/README.md
@@ -21,3 +21,35 @@ CONTENTFUL_ENVIRONMENT=<the desired environment (ex: dev or master)>
 ```
 Any errors that occur during the import will be logged to your terminal.
 Access [Contentful](https://app.contentful.com/) to view/publish the posted buildings.
+
+## Dev Tips
+If it is easier to obtain only the text address of each building for the import, you can upload the spreadsheet to Google Sheets, select the Tools menu and then Script editor. This should open a page called Apps Script.
+
+In the Apps Script page, add the function `GEOCODE_GOOGLE` as in the following snippet:
+```javascript
+/**
+ * Returns latitude and longitude values for given address using the Google Maps Geocoder.
+ *
+ * @param {string} address - The address you get the latitude and longitude for.
+ * @customfunction
+ * 
+ * @source https://community.looker.com/dashboards-looks-7/get-latitude-longitude-for-any-location-through-google-sheets-and-plot-these-in-looker-5402
+ */
+function GEOCODE_GOOGLE(address) {
+  if (address.map) {
+    return address.map(GEOCODE_GOOGLE)
+  } else {
+    var r = Maps.newGeocoder().geocode(address)
+    for (var i = 0; i < r.results.length; i++) {
+      var res = r.results[i]
+      return res.geometry.location.lat + ", " + res.geometry.location.lng
+    }
+  }
+}
+```
+
+You can then add Latitude and Longitude columns, parsing the each value out of this function's response.
+example value for the Latitude cell, presuming the text address is in cell A2:
+`=INDEX(SPLIT(GEOCODE_GOOGLE(N13), ", "),0, 1)`
+or for Longitude:
+`=INDEX(SPLIT(GEOCODE_GOOGLE(N13), ", "),0, 2)`

--- a/scripts/import-property-list/README.md
+++ b/scripts/import-property-list/README.md
@@ -50,6 +50,9 @@ function GEOCODE_GOOGLE(address) {
 
 You can then add Latitude and Longitude columns, parsing the each value out of this function's response.
 example value for the Latitude cell, presuming the text address is in cell A2:
+
 `=INDEX(SPLIT(GEOCODE_GOOGLE(N13), ", "),0, 1)`
+
 or for Longitude:
+
 `=INDEX(SPLIT(GEOCODE_GOOGLE(N13), ", "),0, 2)`

--- a/scripts/import-property-list/README.md
+++ b/scripts/import-property-list/README.md
@@ -49,10 +49,10 @@ function GEOCODE_GOOGLE(address) {
 ```
 
 You can then add Latitude and Longitude columns, parsing the each value out of this function's response.
-example value for the Latitude cell, presuming the text address is in cell A2:
+Example value for the Latitude cell, presuming the text address is in cell A2:
 
-`=INDEX(SPLIT(GEOCODE_GOOGLE(N13), ", "),0, 1)`
+`=INDEX(SPLIT(GEOCODE_GOOGLE(A2), ", "),0, 1)`
 
 or for Longitude:
 
-`=INDEX(SPLIT(GEOCODE_GOOGLE(N13), ", "),0, 2)`
+`=INDEX(SPLIT(GEOCODE_GOOGLE(A2), ", "),0, 2)`

--- a/scripts/import-property-list/README.md
+++ b/scripts/import-property-list/README.md
@@ -1,9 +1,10 @@
 # Import Buildings from XLSX File
 ## Usage
 - Configure an upload spreadsheet with columns named:
--- Building Name
--- Address
--- Latitude
+    - Building Name
+    - Address
+    - Latitude
+    - Longitude
 - Fill the values for each building
 - Obtain your [personal access token](https://app.contentful.com/account/profile/cma_tokens) from Contentful
 - Add a file to the root of the `world-of-jackson` repo called ".env"

--- a/scripts/import-property-list/ts-node-import-xlsx.ts
+++ b/scripts/import-property-list/ts-node-import-xlsx.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env ts-node-script
+import fs = require("fs");
+import { XlsxFormatter, tableConfig } from "../../utils/import-xlsx"
+
+const filePath: string = process.argv[2];
+const pathToConfig: string = process.argv[3];
+
+let config: tableConfig;
+
+const defaultConfig: tableConfig = {
+    name: "Building Name",
+    lat: "Latitude",
+    long: "Longitude"
+}
+
+try {
+    config = require(pathToConfig);
+} catch (err) {
+    console.warn(`Error getting table config from ${pathToConfig}: `, err);
+}
+if (!config) {
+    config = defaultConfig;
+}
+console.log(`Using this config for table header names: `, JSON.stringify(config, undefined, 2));
+
+if (!filePath) {
+    const usageMsg: string = `
+    Usage: yarn import-xlsx <file path to excel file>
+    `
+    console.log(usageMsg)
+} else {
+    importXlsxPropertyList(filePath)
+}
+
+function importXlsxPropertyList(filePath: string) {
+    let fileBlob: Buffer
+    // first block, obtain input file
+    try {
+        // check for read access to file
+        fs.accessSync(filePath, fs.constants.R_OK)
+        fileBlob = fs.readFileSync(filePath)
+        console.log(`successfully read ${fileBlob.length} bits from file`)
+    } catch (err) {
+        console.warn(err)
+    }
+
+    // second block, parse file data
+    const xlsxFormatter = new XlsxFormatter(config);
+    try {
+        xlsxFormatter.initSpreadsheet(fileBlob)
+    } catch (err) {
+        console.warn(err)
+    }
+    // third block, post to contentful
+    try {
+        xlsxFormatter.uploadContent();
+    } catch (err) {
+        console.log(err);
+    }
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "comment": "sets isolatedModules to false for ts-node script in this directory only",
+  "compilerOptions": {
+    "isolatedModules": false,
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
     },
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "scripts"
   ],
   "include": [
     "next-env.d.ts",

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,0 +1,8 @@
+export function tsMatch(str: string, matcher: RegExp): string {
+    let matched = str.match(matcher)
+    if (matched !== null) {
+        return matched.reduce( (a, b) => a + b, "");
+    } else {
+        return "";
+    }
+}

--- a/utils/import-xlsx.ts
+++ b/utils/import-xlsx.ts
@@ -1,0 +1,196 @@
+const XLSX = require("xlsx");
+const getContentfulEnv = require("../getContentfulEnvironment");
+import { IBuildingFields, CONTENTFUL_DEFAULT_LOCALE_CODE } from "../types/db/contentful";
+import { tsMatch } from "./helpers";
+
+export type tableConfig = {
+  name: string;
+  lat: string;
+  long: string;
+}
+
+type ImportXlsx = {
+  read(fileBlob: Buffer): ImportSpreadSheet;
+};
+
+type ImportSpreadSheet = {
+  Sheets: {
+    [key: string]: ImportWorkSheet;
+  };
+};
+
+interface ImportWorkSheetIface {
+  "!ref": string;
+}
+
+type ImportWorkSheet = ImportWorkSheetIface & {
+  [key: string]: ImportCell;
+};
+
+type ImportCell = { w: string };
+
+type colRowSheetName = { sheetName: string; col: string; row: string };
+
+function validateTableConfig(config: tableConfig): tableConfig {
+  if (
+    config.name === undefined ||
+    config.lat === undefined ||
+    config.long === undefined
+  ) {
+    throw new Error("Invalid config. Must have properties: name, lat, long");
+  }
+  return config;
+}
+
+interface IBuildingFieldsForTransmission {
+  fields: {
+    name: { [key: string]: string };
+    latitutde: { [key: string]: number };
+    longitude: { [key: string]: number };
+    address: {
+      [key: string]: {
+        lat: number;
+        lon: number;
+      }
+    }
+  }
+}
+
+export class XlsxFormatter {
+  xlsx: ImportXlsx;
+  config: tableConfig;
+  spreadSheet: ImportSpreadSheet;
+  sheets: string[];
+  buildings: IBuildingFieldsForTransmission[];
+  buildingsMap: { [key: string]: IBuildingFields };
+
+  constructor(config: tableConfig) {
+    this.xlsx = XLSX;
+    this.config = validateTableConfig(config);
+    // initialize properties to empty values
+    this.spreadSheet = { Sheets: {} };
+    this.sheets = [];
+    this.buildings = [];
+    this.buildingsMap = {};
+  }
+
+  initSpreadsheet(fileBlob: Buffer) {
+    this.spreadSheet = this.xlsx.read(fileBlob);
+    this.sheets = Object.keys(this.spreadSheet.Sheets);
+
+    this.findContent(this.config.name, "name");
+    this.findContent(this.config.lat, "lat");
+    this.findContent(this.config.long, "long");
+  }
+
+  async uploadContent() {
+    const env = await getContentfulEnv();
+    for (const bldg of Object.values(this.buildingsMap)) {
+      console.log("Object to post:");
+      console.log(JSON.stringify(this.prepareBuildingForTransmission(bldg), undefined, 2));
+      try {
+        env.createEntry('building', this.prepareBuildingForTransmission(bldg));
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  }
+
+  prepareBuildingForTransmission(bldg: IBuildingFields): IBuildingFieldsForTransmission {
+    const localeCode: CONTENTFUL_DEFAULT_LOCALE_CODE = "en-US"
+    const lat = bldg.address.lat;
+    const lon = bldg.address.lon;
+    return {
+      fields: {
+        name: { [localeCode]: bldg.name },
+        latitutde: { [localeCode]: lat},
+        longitude: { [localeCode]: lon},
+        address: {
+          [localeCode]: { lat, lon }
+        }
+      }
+    }
+  }
+
+  findContent(field: string, conf: "name" | "lat" | "long") {
+    let nameColRowSheet: colRowSheetName = { col: "", row: "", sheetName: "" };
+    let contentSheet: ImportWorkSheet;
+    let startOfData = 0;
+    let endOfData = 0;
+    for (const sheet of this.sheets) {
+      nameColRowSheet = this.findHeaderColRow(sheet, field);
+      if (
+        nameColRowSheet.col.length > 0 &&
+        nameColRowSheet.row.length > 0 &&
+        nameColRowSheet.sheetName.length > 0
+      ) {
+        contentSheet = this.spreadSheet.Sheets[sheet];
+        startOfData = Number(nameColRowSheet.row) + 1;
+        endOfData = Number(this.getRow(contentSheet["!ref"].split(":")[1]));
+        for (let i = startOfData; i <= endOfData; i++) {
+          let cellName: string = `${nameColRowSheet.col}${i}`
+          let mapKey: string = `${nameColRowSheet.sheetName}_${i}`
+          if (contentSheet[cellName]) {
+            let bldg: IBuildingFields = this.buildingsMap[mapKey];
+            if (!bldg) {
+              bldg = {
+                name: '',
+                address: {
+                  lat: 0,
+                  lon: 0
+                }
+              };
+            }
+            let content: string = contentSheet[cellName].w;
+            switch (conf) {
+              case "name":
+                bldg.name = content;
+                break;
+              case "lat":
+                bldg.address.lat = Number(content);
+                break;
+              case "long":
+                bldg.address.lon = Number(content);
+                break;
+              default:
+                throw new Error(`Invalid config name: ${conf}`);
+            }
+            this.buildingsMap[mapKey] = bldg;
+          }
+        }
+      }
+    }
+  }
+
+  findHeaderColRow(sheet: string, header: string): colRowSheetName {
+    let sheetName: string = "";
+    let addressCol: string = "";
+    let addressRow: string = "";
+    const checkSheet = this.spreadSheet.Sheets[sheet];
+    const cellNames: string[] = Object.keys(checkSheet);
+    for (const cellName of cellNames) {
+      if (
+        cellName !== "!ref" &&
+        checkSheet[cellName]?.w.toLowerCase() == header.toLowerCase() || null
+      ) {
+        sheetName = sheet;
+        addressCol = this.getCol(cellName);
+        addressRow = this.getRow(cellName);
+        break;
+      }
+    }
+    return {
+      sheetName,
+      col: addressCol,
+      row: addressRow,
+    };
+  }
+
+  getCol(cell: string): string {
+    return tsMatch(cell, /[A-Z]/g);
+  }
+
+  getRow(cell: string): string {
+    return tsMatch(cell, /[0-9]/g)
+  }
+}

--- a/utils/import-xlsx.ts
+++ b/utils/import-xlsx.ts
@@ -61,7 +61,6 @@ export class XlsxFormatter {
   config: tableConfig;
   spreadSheet: ImportSpreadSheet;
   sheets: string[];
-  buildings: IBuildingFieldsForTransmission[];
   buildingsMap: { [key: string]: IBuildingFields };
 
   constructor(config: tableConfig) {
@@ -70,7 +69,6 @@ export class XlsxFormatter {
     // initialize properties to empty values
     this.spreadSheet = { Sheets: {} };
     this.sheets = [];
-    this.buildings = [];
     this.buildingsMap = {};
   }
 

--- a/utils/import-xlsx.ts
+++ b/utils/import-xlsx.ts
@@ -167,9 +167,10 @@ export class XlsxFormatter {
     const checkSheet = this.spreadSheet.Sheets[sheet];
     const cellNames: string[] = Object.keys(checkSheet);
     for (const cellName of cellNames) {
+      console.log(checkSheet[cellName])
       if (
         cellName !== "!ref" &&
-        checkSheet[cellName]?.w.toLowerCase() == header.toLowerCase() || null
+        checkSheet[cellName]?.w?.toLowerCase() == header?.toLowerCase() || null
       ) {
         sheetName = sheet;
         addressCol = this.getCol(cellName);


### PR DESCRIPTION
Here's a [Loom](https://www.loom.com/share/02ce945a4e214992812eb8064e1652e5) of me testing it with a weird spreadsheet (which I will link on issue #66).

So, my concerns: 

- The way our "Building" types are set up in Contentful, the longitude and latitude are required fields to create the record. This means they'll have to be added to to the import spreadsheet, which I don't think is ideal in terms of usability. 
    - We could solve this by getting some google maps API keys to have the script do the lookup
    - or a clever dev could upload the XLSX to Google Sheets and write a custom function to look up the coordinates from the text address
- I also noticed that even when the coordinates are obtained from Contentful itself (which is using Google Maps' API to look them up from the text address, and I did think about trying to nab that request from the browser & see if there was a way to implement it in the script, but haven't actually done it as it's likely against TOS) the text address in the reverse lookup (coordinates to address) isn't always the address used to obtain the coordinates. I want to think there is a way to do a second pass where we pull down the uploaded buildings and "correct" the text address, but that field is just a { lat, lon } property)